### PR TITLE
README: fix broken json in example config

### DIFF
--- a/packages/codegen/src/README.md.ejs
+++ b/packages/codegen/src/README.md.ejs
@@ -123,7 +123,7 @@ The extension can be customized by modifying your `settings.json` file. The avai
 `keybindings.json`:
 
 ```json:keybindings.json
-{
+[
   {
     "key": "cmd+enter",
     "command": "bigqueryRunner.run",
@@ -139,7 +139,7 @@ The extension can be customized by modifying your `settings.json` file. The avai
     "command": "bigqueryRunner.nextPage",
     "when": "resourceLangId in bigqueryRunner.languageIds || resourceExtname in bigqueryRunner.extensions && vim.mode == 'Normal' || vim.mode == 'Visual' || vim.mode == 'VisualBlock' || vim.mode == 'VisualLine'"
   }
-}
+]
 ```
 
 ### Syntax highlighting `.bqsql` files as SQL


### PR DESCRIPTION
Current example config is broken json, so one cannot copy-paste it and get it working. This PR fixes json making it work out-of-the box