### PR TITLE
Wrap values of 'INT64' type in BigQueryInt objects

### DIFF
--- a/packages/core/src/bigquery.ts
+++ b/packages/core/src/bigquery.ts
@@ -252,6 +252,7 @@ export async function createClient(
             return job.getQueryResults({
               maxResults: jobOptions.maxResults,
               pageToken,
+              wrapIntegers: true,
             });
           },
           (err) => ({

--- a/packages/misc/queries/types.bqsql
+++ b/packages/misc/queries/types.bqsql
@@ -1,7 +1,7 @@
 declare a bignumeric(10) default cast('999999' as bignumeric(10));
 declare d bytes(10) default cast('foo' as bytes(10));
 declare e float64 default cast('3.14' as float64);
-declare f int64 default cast('3' as int64);
+declare f int64 default cast('9162371277713859723' as int64);
 DECLARE y NUMERIC(5, 2) DEFAULT 123.45;
 
 select

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -13,6 +13,7 @@ import type {
   RoutinePayload,
   MetadataPayload,
   TablePayload,
+  Err,
   Format,
   Tab as TabName,
   TableReference,
@@ -28,7 +29,6 @@ import {
   isStartProcessingEvent,
   isSuccessLoadingEvent,
   isFailProcessingEvent,
-  type Err,
 } from "shared";
 import type { WebviewApi } from "vscode-webview";
 import { Header } from "./domain/Header";


### PR DESCRIPTION
Fixes #54

[Docs](https://googleapis.dev/nodejs/bigquery/latest/Table.html#:~:text=results%20to%20return.-,wrapIntegers,-boolean%20%7C%20IntegerTypeCastOptions)

before:
![image](https://github.com/minodisk/bigquery-runner/assets/514164/e3515e38-5ed8-4622-a16a-1c1e41f4e91d)

after:
![image](https://github.com/minodisk/bigquery-runner/assets/514164/65df8e91-4740-457a-8410-f567bd0fa111)